### PR TITLE
Fixed a bug (wrong type) that did not allow the library to compile on Arduino 1.6.0

### DIFF
--- a/Libraries/SFE_TSL2561/SFE_TSL2561.cpp
+++ b/Libraries/SFE_TSL2561/SFE_TSL2561.cpp
@@ -404,7 +404,7 @@ boolean SFE_TSL2561::readUInt(unsigned char address, unsigned int &value)
 }
 
 
-byte SFE_TSL2561::writeUInt(unsigned char address, unsigned int value)
+boolean SFE_TSL2561::writeUInt(unsigned char address, unsigned int value)
 	// Write an unsigned integer (16 bits) to a TSL2561 address (low byte first)
 	// Address: TSL2561 address (0 to 15), low byte first
 	// Value: unsigned int to write to address


### PR DESCRIPTION
I was getting an error because the function declaration in SFE_TSL2561.h sets the return value as a boolean (not a byte). The function actually appears to be returning a boolean, so I corrected it in the cpp file.